### PR TITLE
Allow Travis to fail on Windows on Julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ julia:
 matrix:
   allow_failures:
   - julia: nightly
+    os: windows
   fast_finish: true
 
 notifications:


### PR DESCRIPTION
But do not allow any other platform+Julia version combinations to fail