### PR TITLE
Add support for exclude markers.

### DIFF
--- a/src/CoverageTools.jl
+++ b/src/CoverageTools.jl
@@ -215,7 +215,6 @@ module CoverageTools
 
                 # also check for line markers
                 if excluded || occursin("COV_EXCL_LINE", line)
-                    @debug "removing line $l: $line"
                     coverage[l] = nothing
                 end
             end

--- a/src/CoverageTools.jl
+++ b/src/CoverageTools.jl
@@ -201,6 +201,26 @@ module CoverageTools
                 end
             end
         end
+
+        # check for excluded lines
+        let io = IOBuffer(content)
+            excluded = false
+            for (l, line) in enumerate(eachline(io))
+                # check for start/stop markers
+                if occursin("COV_EXCL_START", line)
+                    excluded = true
+                elseif occursin("COV_EXCL_STOP", line)
+                    excluded = false
+                end
+
+                # also check for line markers
+                if excluded || occursin("COV_EXCL_LINE", line)
+                    @debug "removing line $l: $line"
+                    coverage[l] = nothing
+                end
+            end
+        end
+
         nothing
     end
 

--- a/test/exclusions.jl
+++ b/test/exclusions.jl
@@ -1,0 +1,9 @@
+function main()
+    println(devnull, 1)
+    println(devnull, 2) # COV_EXCL_LINE
+    println(devnull, 3)
+    # COV_EXCL_START
+    println(devnull, 4)
+    # COV_EXCL_STOP
+    println(devnull, 5)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,6 +151,19 @@ end
         @test isfile(joinpath(datadir_temp, "CoverageTools.jl"))
         # tear down test data
         rm(datadir_temp; recursive=true)
+
+        # test exclusion markers
+        srcname = joinpath("test", "exclusions.jl")
+        covname = srcname*".cov"
+        clean_file(srcname)
+        cmdstr = "include($(repr(srcname))); main()"
+        run(`$(Base.julia_cmd()) --startup-file=no --code-coverage=user -e $cmdstr`)
+        r = withenv("DISABLE_AMEND_COVERAGE_FROM_SRC" => "yes") do
+            process_file(srcname, "test")
+        end
+        @test r.coverage == [nothing, 2, 1, 1, nothing, 1, nothing, 1, nothing, nothing]
+        amend_coverage_from_src!(r.coverage, r.filename)
+        @test r.coverage == [nothing, 2, nothing, 1, nothing, nothing, nothing, 1, nothing, nothing]
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,7 +117,11 @@ end
         run(`$(Base.julia_cmd()) --startup-file=no --code-coverage=user -e $cmdstr`)
         r = process_file(srcname, datadir)
 
-        target = CoverageTools.CovCount[nothing, 2, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing]
+        target = if VERSION >= v"1.5.0-DEV.42"
+            CoverageTools.CovCount[nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing]
+        else
+            CoverageTools.CovCount[nothing, 2, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing]
+        end
         target_disabled = map(x -> (x !== nothing && x > 0) ? x : nothing, target)
         @test r.coverage == target
 
@@ -161,9 +165,20 @@ end
         r = withenv("DISABLE_AMEND_COVERAGE_FROM_SRC" => "yes") do
             process_file(srcname, "test")
         end
-        @test r.coverage == [nothing, 2, 1, 1, nothing, 1, nothing, 1, nothing, nothing]
-        amend_coverage_from_src!(r.coverage, r.filename)
-        @test r.coverage == [nothing, 2, nothing, 1, nothing, nothing, nothing, 1, nothing, nothing]
+        # FIXME: coverage information for this function is useless with Julia 1.0
+        if VERSION >= v"1.1"
+            @test r.coverage == if VERSION >= v"1.5.0-DEV.42"
+                [nothing, 1, 1, 1, nothing, 1, nothing, 1, nothing]
+            else
+                [nothing, 2, 1, 1, nothing, 1, nothing, 1, nothing, nothing]
+            end
+            amend_coverage_from_src!(r.coverage, r.filename)
+            @test r.coverage == if VERSION >= v"1.5.0-DEV.42"
+                [nothing, 1, nothing, 1, nothing, nothing, nothing, 1, nothing]
+            else
+                [nothing, 2, nothing, 1, nothing, nothing, nothing, 1, nothing, nothing]
+            end
+        end
     end
 end
 


### PR DESCRIPTION
This PR adds support for three simple source markers that remove coverage: `COV_EXCL_LINE` to exclude a single line, and `COV_EXCL_START` to `COV_EXCL_STOP` to define respectively the start and end of a section of code that should be excluded. These mimic (and are compatible with) similar markers as found in lcov and gcov: http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php

The changes are based on https://github.com/JuliaCI/Coverage.jl/pull/218, but I left out support for excluding files (and the ability to configure using a `.coverage.yml`) because that is covered by existing tools already: Codecov.io supports an `ignore` list in its `.codecov.yml`, and LCOV tracefiles can be pruned with `lcov --remove`. We can always add that functionality later on, but this seems like a straightforward first step.