### PR TITLE
Remove `LibGit2` from the list of dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Iain Dunning
+Copyright (c) 2014 Iain Dunning and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,7 @@
 name = "CoverageTools"
 uuid = "c36e975a-824b-4404-a568-ef97ca766997"
 authors = ["Iain Dunning <iaindunning@gmail.com>"]
-version = "1.2.2"
-
-[deps]
-LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.2.3"
 
 [compat]
 julia = "0.7, 1"

--- a/src/CoverageTools.jl
+++ b/src/CoverageTools.jl
@@ -5,7 +5,6 @@
 # https://github.com/JuliaCI/CoverageTools.jl
 #######################################################################
 module CoverageTools
-    using LibGit2
 
     export process_folder, process_file
     export clean_folder, clean_file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 # https://github.com/JuliaCI/CoverageTools.jl
 #######################################################################
 
-using CoverageTools, Test, LibGit2
+using CoverageTools, Test
 
 if VERSION < v"1.1-"
 isnothing(x) = false


### PR DESCRIPTION
We don't actually use `LibGit2`, so I've removed it from the list of dependencies.