### PR TITLE
For the CI on this repository, do not submit to Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
             arch: x86
           - version: '1'
             os: windows-latest
+            arch: x86
+          - version: '1'
+            os: windows-latest
             arch: x64
           - version: '1'
             os: macos-latest
@@ -55,18 +58,3 @@ jobs:
         if: github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name
         with:
           file: lcov.info
-      - uses: coverallsapp/github-action@master
-        with:
-          path-to-lcov: lcov.info
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: run-${{ matrix.test_number }}
-          parallel: true
-  finish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@ CoverageTools.jl - you probably want [Coverage.jl](https://github.com/JuliaCI/Co
 ===========
 
 [![Build Status](https://github.com/JuliaCI/CoverageTools.jl/workflows/CI/badge.svg)](https://github.com/JuliaCI/CoverageTools.jl/actions/workflows/CI.yml?query=branch%3Amaster)
-[![coveralls](https://coveralls.io/repos/github/JuliaCI/CoverageTools.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaCI/CoverageTools.jl?branch=master)
-[![codecov](https://codecov.io/gh/JuliaCI/CoverageTools.jl/branch/master/graph/badge.svg?label=codecov&token=71csaj8Nxg)](https://codecov.io/gh/JuliaCI/CoverageTools.jl)
-
+[![Codecov](https://codecov.io/gh/JuliaCI/CoverageTools.jl/branch/master/graph/badge.svg?label=codecov&token=71csaj8Nxg)](https://codecov.io/gh/JuliaCI/CoverageTools.jl)
 
 CoverageTools.jl provides the core functionality for processing code coverage and memory allocation results.
 

--- a/src/lcov.jl
+++ b/src/lcov.jl
@@ -2,6 +2,7 @@
 # can be parsed by a variety of useful utilities to display coverage info
 
 export LCOV
+
 """
 CoverageTools.LCOV Module
 
@@ -140,4 +141,4 @@ function readfolder(folder)
     return source_files
 end
 
-end
+end # module


### PR DESCRIPTION
For some reason, the `coverallsapp/github-action` action uses our `GITHUB_TOKEN`, which has write access to this repository. I'm not sure why we need to give Coveralls a token that has write access to our repo.

Codecov uses its own `CODECOV_TOKEN`, which has no permissions outside of Codecov.

If Coveralls adds the ability to use their own Codecov repo token, then we can add Coveralls back.

(This is only for CI on this repository. It has no effect on whether or not users can use Coveralls on their own packages and repositories.)