### PR TITLE
Codecov: add the `codecov/minimum` commit status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+      minimum:
+        target: "100%"


### PR DESCRIPTION
Now that we have code coverage at 100% on this repository, we should keep it at 100%.