### PR TITLE
Rename CI badge to match workflow renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CoverageTools.jl - you probably want [Coverage.jl](https://github.com/JuliaCI/Coverage.jl) instead
 ===========
 
-[![Build Status](https://github.com/JuliaCI/CoverageTools.jl/workflows/CI/badge.svg)](https://github.com/JuliaCI/CoverageTools.jl/actions/workflows/CI.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/JuliaCI/CoverageTools.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaCI/CoverageTools.jl/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Codecov](https://codecov.io/gh/JuliaCI/CoverageTools.jl/branch/master/graph/badge.svg?label=codecov&token=71csaj8Nxg)](https://codecov.io/gh/JuliaCI/CoverageTools.jl)
 
 CoverageTools.jl provides the core functionality for processing code coverage and memory allocation results.


### PR DESCRIPTION
Not sure why the action was renamed, but it necessitates renaming the badge too