### PR TITLE
Drop support for Julia 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "CoverageTools"
 uuid = "c36e975a-824b-4404-a568-ef97ca766997"
 authors = ["Iain Dunning <iaindunning@gmail.com>", "contributors"]
-version = "1.2.7"
+version = "1.3.0"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I don't think we need to keep supporting Julia 0.7 at this point.

As a point of reference, here is the current Julia `[compat]` entry for Coverage.jl:
```toml
[compat]
julia = "1"
```