### PR TITLE
Detect syntax version from project files to support parsing newer Julia syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
+          - 'min'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "CoverageTools"
 uuid = "c36e975a-824b-4404-a568-ef97ca766997"
-authors = ["Iain Dunning <iaindunning@gmail.com>", "contributors"]
 version = "1.3.2"
+authors = ["Iain Dunning <iaindunning@gmail.com>", "contributors"]
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
+JuliaSyntax = "1"
+TOML = "1"
 julia = "1"
-JuliaSyntax = "0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [compat]
 JuliaSyntax = "1"
 TOML = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,12 @@ uuid = "c36e975a-824b-4404-a568-ef97ca766997"
 authors = ["Iain Dunning <iaindunning@gmail.com>", "contributors"]
 version = "1.3.2"
 
+[deps]
+JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+
 [compat]
 julia = "1"
+JuliaSyntax = "0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/CoverageTools.jl
+++ b/src/CoverageTools.jl
@@ -249,12 +249,12 @@ function detect_syntax_version(filename::AbstractString)
         # Check for VERSION file (for Julia's own base/ source without project file)
         version_file = joinpath(dir, "VERSION")
         if isfile(version_file)
+            version_str = nothing
             try
                 version_str = strip(read(version_file, String))
             catch e
                 e isa SystemError || rethrow()
                 # If we can't read VERSION, continue searching
-                version_str = nothing
             end
             if version_str !== nothing
                 # Parse version string like "1.14.0-DEV"

--- a/src/CoverageTools.jl
+++ b/src/CoverageTools.jl
@@ -21,17 +21,9 @@ const CovCount = Union{Nothing,Int}
 Recursively check if an expression contains any `:error` nodes.
 """
 function has_embedded_errors(expr)
-    if expr isa Expr
-        if expr.head === :error
-            return true
-        end
-        for arg in expr.args
-            if has_embedded_errors(arg)
-                return true
-            end
-        end
-    end
-    return false
+    expr isa Expr || return false
+    expr.head === :error && return true
+    return any(has_embedded_errors, expr.args)
 end
 
 """
@@ -327,8 +319,8 @@ function amend_coverage_from_src!(fc::FileCoverage)
         # that later on to shift other one-based line numbers, we must
         # subtract 1 from the offset to make it zero-based.
         lineoffset = searchsortedlast(linepos, pos - 1) - 1
-        # Compute actual 1-based line number for error reporting
-        current_line = searchsortedlast(linepos, pos - 1)
+        # 1-based line number for error reporting (lineoffset is 0-based)
+        current_line = lineoffset + 1
 
         # now we can parse the next chunk of the input
         local ast, newpos

--- a/test/BustedPackage/src/error_after_first.jl
+++ b/test/BustedPackage/src/error_after_first.jl
@@ -1,0 +1,6 @@
+# Test file with error after first statement
+x = 1
+
+for i [1,2,3]
+    println(i)
+end

--- a/test/BustedPackage/src/error_eof.jl
+++ b/test/BustedPackage/src/error_eof.jl
@@ -1,0 +1,3 @@
+# Test file with unexpected EOF
+function foo()
+    x = 1

--- a/test/BustedPackage/src/error_middle.jl
+++ b/test/BustedPackage/src/error_middle.jl
@@ -1,0 +1,14 @@
+# Test file with error in middle
+function works()
+    return 1
+end
+
+function broken()
+    for x [1,2,3]
+        println(x)
+    end
+end
+
+function also_works()
+    return 2
+end

--- a/test/BustedPackage/src/error_start.jl
+++ b/test/BustedPackage/src/error_start.jl
@@ -1,0 +1,4 @@
+# Test file with error at beginning
+function [invalid syntax
+    return 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,6 +294,7 @@ end # testset
 
     # Test explicit syntax.julia_version in Project.toml
     if isdefined(Base, :project_file_load_spec)
+        # Julia 1.14+ uses Base.project_file_load_spec
         mktempdir() do dir
             project = joinpath(dir, "Project.toml")
             write(project, """
@@ -308,6 +309,20 @@ end # testset
             # since syntax versioning was first introduced in 1.14. We specified 1.11,
             # so it should read from Project.toml and clamp to 1.13 (not default to 1.14)
             @test version == v"1.13"
+        end
+    else
+        # Test TOML fallback path for Julia < 1.14
+        mktempdir() do dir
+            project = joinpath(dir, "Project.toml")
+            write(project, """
+                name = "TestPkg"
+                [syntax]
+                julia_version = "1.12"
+                """)
+            testfile = joinpath(dir, "test.jl")
+            write(testfile, "x = 1")
+            version = CoverageTools.detect_syntax_version(testfile)
+            @test version == v"1.12"
         end
     end
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,11 +198,8 @@ end # testset
     elseif VERSION.major == 1 && VERSION.minor == 5
         msg = "parsing error in $bustedfile:7: space before \"[\" not allowed in \"i [\" at none:4"
     elseif VERSION.major == 1 && VERSION.minor > 9
-        msg = if Sys.iswindows()
-            """parsing error in $bustedfile:8: Base.Meta.ParseError(\"ParseError:\\n# Error @ none:3:10\\n    s = 0\\r\\n    for i [1,2,3]   # this line has a parsing error\\r\\n#        └─┘ ── invalid iteration spec: expected one of `=` `in` or `∈`\", Base.JuliaSyntax.ParseError(Base.JuliaSyntax.SourceFile(\"function parseerr()\\r\\n    s = 0\\r\\n    for i [1,2,3]   # this line has a parsing error\\r\\n        \", 46, \"none\", 1, [1, 22, 33, 86, 94]), Base.JuliaSyntax.Diagnostic[Base.JuliaSyntax.Diagnostic(88, 90, :error, \"invalid iteration spec: expected one of `=` `in` or `∈`\"), Base.JuliaSyntax.Diagnostic(93, 92, :error, \"invalid iteration spec: expected one of `=` `in` or `∈`\"), Base.JuliaSyntax.Diagnostic(95, 94, :error, \"invalid iteration spec: expected one of `=` `in` or `∈`\"), Base.JuliaSyntax.Diagnostic(95, 95, :error, \"unexpected `]`\"), Base.JuliaSyntax.Diagnostic(95, 94, :error, \"Expected `end`\"), Base.JuliaSyntax.Diagnostic(95, 94, :error, \"Expected `end`\"), Base.JuliaSyntax.Diagnostic(95, 95, :error, \"extra tokens after end of expression\")], :none))"""
-        else
-            """parsing error in $bustedfile:8: Base.Meta.ParseError(\"ParseError:\\n# Error @ none:3:10\\n    s = 0\\n    for i [1,2,3]   # this line has a parsing error\\n#        └─┘ ── invalid iteration spec: expected one of `=` `in` or `∈`\", Base.JuliaSyntax.ParseError(Base.JuliaSyntax.SourceFile(\"function parseerr()\\n    s = 0\\n    for i [1,2,3]   # this line has a parsing error\\n        \", 42, \"none\", 1, [1, 21, 31, 83, 91]), Base.JuliaSyntax.Diagnostic[Base.JuliaSyntax.Diagnostic(82, 84, :error, \"invalid iteration spec: expected one of `=` `in` or `∈`\"), Base.JuliaSyntax.Diagnostic(87, 86, :error, \"invalid iteration spec: expected one of `=` `in` or `∈`\"), Base.JuliaSyntax.Diagnostic(89, 88, :error, \"invalid iteration spec: expected one of `=` `in` or `∈`\"), Base.JuliaSyntax.Diagnostic(89, 89, :error, \"unexpected `]`\"), Base.JuliaSyntax.Diagnostic(89, 88, :error, \"Expected `end`\"), Base.JuliaSyntax.Diagnostic(89, 88, :error, \"Expected `end`\"), Base.JuliaSyntax.Diagnostic(89, 89, :error, \"extra tokens after end of expression\")], :none))"""
-        end
+        # With JuliaSyntax, the error is detected on the line where the statement starts
+        msg = "parsing error in $bustedfile:7"
     else
         msg = "parsing error in $bustedfile:7: invalid iteration specification"
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,6 +265,21 @@ end # testset
     @test err isa Base.Meta.ParseError
     @test occursin(":7", err.msg)  # Error on line 7
 
+    # Test error after first statement - should report correct line
+    error_after_first = joinpath(srcdir, "error_after_first.jl")
+    err_after = try
+        process_file(error_after_first, srcdir)
+        nothing
+    catch e
+        e
+    end
+    @test err_after isa Base.Meta.ParseError
+    @test occursin(":4", err_after.msg)  # Error on line 4
+
+    # Test unexpected EOF should raise a parse error (not be silently ignored)
+    error_eof = joinpath(srcdir, "error_eof.jl")
+    @test_throws Base.Meta.ParseError process_file(error_eof, srcdir)
+
     clean_folder(srcdir)
 end # testset
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,11 +204,11 @@ end # testset
         msg = "parsing error in $bustedfile:7: invalid iteration specification"
     end
     @test_throws Base.Meta.ParseError(msg) process_file(bustedfile, srcdir)
-    
+
     # Test error at beginning of file
     error_start = joinpath(srcdir, "error_start.jl")
     @test_throws Base.Meta.ParseError process_file(error_start, srcdir)
-    
+
     # Test error in middle of file - should report correct line
     error_middle = joinpath(srcdir, "error_middle.jl")
     err = try
@@ -219,7 +219,7 @@ end # testset
     end
     @test err isa Base.Meta.ParseError
     @test occursin(":7", err.msg)  # Error on line 7
-    
+
     clean_folder(srcdir)
 end # testset
 
@@ -231,7 +231,7 @@ end # testset
         version = CoverageTools.detect_syntax_version(testfile)
         @test version == v"1.14"
     end
-    
+
     # Test explicit syntax.julia_version in Project.toml
     if isdefined(Base, :project_file_load_spec)
         mktempdir() do dir
@@ -244,7 +244,10 @@ end # testset
             testfile = joinpath(dir, "test.jl")
             write(testfile, "x = 1")
             version = CoverageTools.detect_syntax_version(testfile)
-            @test version == v"1.11"
+            # Julia 1.14+ clamps syntax versions to minimum v"1.13" (NON_VERSIONED_SYNTAX)
+            # since syntax versioning was first introduced in 1.14. We specified 1.11,
+            # so it should read from Project.toml and clamp to 1.13 (not default to 1.14)
+            @test version == v"1.13"
         end
     end
 end # testset


### PR DESCRIPTION
## Add version-aware parsing using JuliaSyntax

This PR enables CoverageTools to parse Julia source code across different syntax versions by:

**Key Changes:**
- Added **JuliaSyntax** as a dependency for version-aware parsing
- Implemented `detect_syntax_version()` to automatically detect the appropriate Julia syntax version by:
  - Checking `Project.toml`/`JuliaProject.toml` for explicit `syntax.julia_version` entries
  - Using `Base.project_file_load_spec()` when available (Julia 1.14+)
  - Falling back to `VERSION` file for Julia's `base/` source tree
  - Defaulting to `v"1.14"` (JuliaSyntax maintains backwards compatibility)
- Modified `amend_coverage_from_src!()` to use `JuliaSyntax.parsestmt()` with the detected version parameter
- Added `has_embedded_errors()` helper to detect parse errors in ASTs with proper error reporting
- Updated test expectations for the new error message format

**Why This Matters:**
This allows CoverageTools running under Julia 1.11 (or any version) to correctly parse Julia 1.14+ source code containing new syntax features like labeled breaks. Since JuliaSyntax provides version-aware parsing independent of the running Julia version, coverage analysis now works seamlessly across version boundaries.

**Implementation Details:**
- Raises minimum Julia version to 1.10 (for compatibility with JuliaSyntax)
- Handles edge cases: comment-only files, EOF detection, infinite loop prevention
- Maintains error reporting for actual syntax errors while being lenient with version-specific features

Fixes JuliaLang/julia#60826

Developed with Claude