### PR TITLE
Fix parsing of labeled break statements

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,19 @@ end
     # Test no error
     ast_no_error = Expr(:block, :(x = 1), :(y = 2))
     @test !CoverageTools.has_embedded_errors(ast_no_error)
+    
+    # Test Expr(:error, :symbol) from "break label" is NOT treated as an error
+    # This can occur when JuliaSyntax parses "break error" where "error" is a label name
+    ast_break_label = Expr(:&&, :(val === nothing), :(break), Expr(:error, :error))
+    @test !CoverageTools.has_embedded_errors(ast_break_label)
+    
+    # Test with other label names
+    ast_break_done = Expr(:block, Expr(:error, :done))
+    @test !CoverageTools.has_embedded_errors(ast_break_done)
+    
+    # But real error messages (strings) should still be detected
+    ast_real_error = Expr(:block, Expr(:error, "syntax error"))
+    @test CoverageTools.has_embedded_errors(ast_real_error)
 end
 
 withenv("DISABLE_AMEND_COVERAGE_FROM_SRC" => nothing) do


### PR DESCRIPTION
When JuliaSyntax parses 'break label' statements where the label name is a keyword like 'error' or 'done', it creates Expr(:error, :label) nodes that look like parse errors but are actually just label references. This was causing false positive parse errors when running Julia 1.11 with JuliaSyntax to parse Julia 1.14+ source code containing constructs like '@label error begin ... break error ... end'.

The fix updates has_embedded_errors() to distinguish between real parse errors (Expr(:error) or Expr(:error, "message")) and false positives (Expr(:error, :symbol) from labeled breaks).

Fixes http://buildkite.com/julialang/julia-master-scheduled/builds/1425#019c1312-26d0-4716-8642-7ac68180293e